### PR TITLE
Use termcolor for better Windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,26 +107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "log"
@@ -140,8 +124,8 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
- "colored",
  "log",
+ "termcolor",
 ]
 
 [[package]]
@@ -180,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +183,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,9 @@ license = "MIT"
 keywords = ["terminal", "log", "logger", "logging", "cli"]
 
 [dependencies]
-colored = "2.2.0"
 log = { version = "0.4", features = ["std"] }
+termcolor = "1.4.1"
 
 [dev-dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
 clap-verbosity-flag = "2.1.2"
-
-[features]
-# Disable printing with ANSI colors. This is intended for supporting older Windows terminals.
-no-color = ["colored/no-color"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ amount of messages.
 ### disable all colorization in case the `stderr` is not a tty or when requested by `NO_COLOR`
 
 so the output is not polluted with unreadable characters when `stderr` is redirected to a file.
-This crate uses the `colored` crate to color text, which disables colorization when `NO_COLOR` is set.
+This crate uses the `termcolor` crate to color text, which disables colorization when `NO_COLOR` is set.
 
 ## Example with `Info` log level
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@
 //!   to help the developer understand where a message comes from, in addition to display a larger
 //!   amount of messages.
 //! * disable all colorization in case the `stderr` is not a tty, so the output is not polluted
-//!   with unreadable characters when `stderr` is redirected to a file.
+//!   with unreadable characters when `stderr` is redirected to a file. This crate uses the
+//!   `termcolor` crate to color text, which disables colorization when `NO_COLOR` is set.
 //!
 //! ## Example with `Info` log level
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 pub const MODULE_PATH_UNKNOWN: &str = "?";
 pub const MODULE_LINE_UNKNOWN: &str = "?";
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Logger {
     level: log::Level,
     writer: Arc<BufferWriter>,
@@ -112,7 +112,9 @@ impl Logger {
         let mut buffer = self.writer.buffer();
 
         // Set the header color
-        buffer.set_color(ColorSpec::new().set_fg(Some(color(level))))?;
+        if let Some(color) = color(level) {
+            buffer.set_color(ColorSpec::new().set_fg(Some(color)))?;
+        }
 
         if !matches!(level, log::Level::Info) {
             write!(buffer, "{}: ", level.to_string().to_lowercase())?;
@@ -138,7 +140,9 @@ impl Logger {
         let mut buffer = self.writer.buffer();
 
         // Set the header color
-        buffer.set_color(ColorSpec::new().set_fg(Some(color(level))))?;
+        if let Some(color) = color(level) {
+            buffer.set_color(ColorSpec::new().set_fg(Some(color)))?;
+        }
 
         write!(
             buffer,
@@ -206,16 +210,16 @@ pub fn init(level: log::Level) -> Result<(), SetLoggerError> {
 }
 
 /// Returns the color associated with the log level
-fn color(level: log::Level) -> Color {
+fn color(level: log::Level) -> Option<Color> {
     if std::io::stderr().is_terminal() {
         match level {
-            log::Level::Error => Color::Red,
-            log::Level::Warn => Color::Yellow,
-            log::Level::Info => Color::White,
-            log::Level::Debug => Color::Blue,
-            log::Level::Trace => Color::Magenta,
+            log::Level::Error => Some(Color::Red),
+            log::Level::Warn => Some(Color::Yellow),
+            log::Level::Info => None,
+            log::Level::Debug => Some(Color::Blue),
+            log::Level::Trace => Some(Color::Magenta),
         }
     } else {
-        Color::White
+        None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,8 +169,10 @@ impl log::Log for Logger {
     fn log(&self, record: &log::Record) {
         if self.enabled(record.metadata()) {
             match self.level {
-                log::Level::Trace => self.log_with_trace(record).unwrap(),
-                _ => self.log_with_level(record).unwrap(),
+                log::Level::Trace => self
+                    .log_with_trace(record)
+                    .expect("Failed to log with trace"),
+                _ => self.log_with_level(record).expect("Failed to log"),
             }
         }
     }


### PR DESCRIPTION
After the previous PR I realized that it's better to have a runtime check for color support than a cargo feature. The `termcolor` crate provides this check and can also talk to the Windows console to generate colored output, in addition to using ANSI escape codes. I think this is a better solution because it provides maximum compatibility across operating systems. 

Apologies for not looking into this before making the previous PR.